### PR TITLE
Feat: Create filebrowser and jupyterlab module

### DIFF
--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -1,0 +1,123 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 0.17"
+    }
+  }
+}
+
+variable "agent_id" {
+  type        = string
+  description = "The ID of a Coder agent."
+}
+
+data "coder_workspace" "me" {}
+
+data "coder_workspace_owner" "me" {}
+
+variable "agent_name" {
+  type        = string
+  description = "The name of the coder_agent resource. (Only required if subdomain is false and the template uses multiple agents.)"
+  default     = null
+}
+
+variable "database_path" {
+  type        = string
+  description = "The path to the filebrowser database."
+  default     = "filebrowser.db"
+  validation {
+    # Ensures path leads to */filebrowser.db
+    condition     = can(regex(".*filebrowser\\.db$", var.database_path))
+    error_message = "The database_path must end with 'filebrowser.db'."
+  }
+}
+
+variable "log_path" {
+  type        = string
+  description = "The path to log filebrowser to."
+  default     = "/tmp/filebrowser.log"
+}
+
+variable "port" {
+  type        = number
+  description = "The port to run filebrowser on."
+  default     = 13339
+}
+
+variable "folder" {
+  type        = string
+  description = "--root value for filebrowser."
+  default     = "~"
+}
+
+variable "share" {
+  type    = string
+  default = "owner"
+  validation {
+    condition     = var.share == "owner" || var.share == "authenticated" || var.share == "public"
+    error_message = "Incorrect value. Please set either 'owner', 'authenticated', or 'public'."
+  }
+}
+
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
+variable "slug" {
+  type        = string
+  description = "The slug of the coder_app resource."
+  default     = "filebrowser"
+}
+
+variable "subdomain" {
+  type        = bool
+  description = <<-EOT
+    Determines whether the app will be accessed via it's own subdomain or whether it will be accessed via a path on Coder.
+    If wildcards have not been setup by the administrator then apps with "subdomain" set to true will not be accessible.
+  EOT
+  default     = true
+}
+
+resource "coder_script" "filebrowser" {
+  agent_id     = var.agent_id
+  display_name = "File Browser"
+  icon         = "/icon/filebrowser.svg"
+  script = templatefile("${path.module}/run.sh", {
+    LOG_PATH : var.log_path,
+    PORT : var.port,
+    FOLDER : var.folder,
+    LOG_PATH : var.log_path,
+    DB_PATH : var.database_path,
+    SUBDOMAIN : var.subdomain,
+    SERVER_BASE_PATH : local.server_base_path
+  })
+  run_on_start = true
+}
+
+resource "coder_app" "filebrowser" {
+  agent_id     = var.agent_id
+  slug         = var.slug
+  display_name = "File Browser"
+  url          = local.url
+  icon         = "/icon/filebrowser.svg"
+  subdomain    = var.subdomain
+  share        = var.share
+  order        = var.order
+
+  healthcheck {
+    url       = local.healthcheck_url
+    interval  = 5
+    threshold = 6
+  }
+}
+
+locals {
+  server_base_path = var.subdomain ? "" : format("/@%s/%s%s/apps/%s", data.coder_workspace_owner.me.name, data.coder_workspace.me.name, var.agent_name != null ? ".${var.agent_name}" : "", var.slug)
+  url              = "http://localhost:${var.port}${local.server_base_path}"
+  healthcheck_url  = "http://localhost:${var.port}${local.server_base_path}/health"
+}

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+BOLD='\033[0;1m'
+
+printf "$${BOLD}Installing filebrowser \n\n"
+
+# Check if filebrowser is installed
+if ! command -v filebrowser &> /dev/null; then
+  curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash
+fi
+
+printf "🥳 Installation complete! \n\n"
+
+printf "👷 Starting filebrowser in background... \n\n"
+
+ROOT_DIR=${FOLDER}
+ROOT_DIR=$${ROOT_DIR/\~/$HOME}
+
+DB_FLAG=""
+if [ "${DB_PATH}" != "filebrowser.db" ]; then
+  DB_FLAG=" -d ${DB_PATH}"
+fi
+
+# set baseurl to be able to run if sudomain=false; if subdomain=true the SERVER_BASE_PATH value will be ""
+filebrowser config set --baseurl "${SERVER_BASE_PATH}"$${DB_FLAG} > ${LOG_PATH} 2>&1
+
+printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
+
+printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG}' \n\n"
+
+filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} > ${LOG_PATH} 2>&1 &
+
+printf "📝 Logs at ${LOG_PATH} \n\n"

--- a/jupyterlab/main.tf
+++ b/jupyterlab/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 0.17"
+    }
+  }
+}
+
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+# Add required variables for your modules and remove any unneeded variables
+variable "agent_id" {
+  type        = string
+  description = "The ID of a Coder agent."
+}
+
+variable "log_path" {
+  type        = string
+  description = "The path to log jupyterlab to."
+  default     = "/tmp/jupyterlab.log"
+}
+
+variable "port" {
+  type        = number
+  description = "The port to run jupyterlab on."
+  default     = 19999
+}
+
+variable "share" {
+  type    = string
+  default = "owner"
+  validation {
+    condition     = var.share == "owner" || var.share == "authenticated" || var.share == "public"
+    error_message = "Incorrect value. Please set either 'owner', 'authenticated', or 'public'."
+  }
+}
+
+variable "subdomain" {
+  type        = bool
+  description = "Determines whether JupyterLab will be accessed via its own subdomain or whether it will be accessed via a path on Coder."
+  default     = true
+}
+
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
+resource "coder_script" "jupyterlab" {
+  agent_id     = var.agent_id
+  display_name = "jupyterlab"
+  icon         = "/icon/jupyter.svg"
+  script = templatefile("${path.module}/run.sh", {
+    LOG_PATH : var.log_path,
+    PORT : var.port
+    BASE_URL : var.subdomain ? "" : "/@${data.coder_workspace_owner.me.name}/${data.coder_workspace.me.name}/apps/jupyterlab"
+  })
+  run_on_start = true
+}
+
+resource "coder_app" "jupyterlab" {
+  agent_id     = var.agent_id
+  slug         = "jupyterlab" # sync with the usage in URL
+  display_name = "JupyterLab"
+  url          = var.subdomain ? "http://localhost:${var.port}" : "http://localhost:${var.port}/@${data.coder_workspace_owner.me.name}/${data.coder_workspace.me.name}/apps/jupyterlab"
+  icon         = "/icon/jupyter.svg"
+  subdomain    = var.subdomain
+  share        = var.share
+  order        = var.order
+}

--- a/jupyterlab/run.sh
+++ b/jupyterlab/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+if [ -n "${BASE_URL}" ]; then
+  BASE_URL_FLAG="--ServerApp.base_url=${BASE_URL}"
+fi
+
+BOLD='\033[0;1m'
+
+printf "$${BOLD}Installing jupyterlab!\n"
+
+# check if jupyterlab is installed
+if ! command -v jupyter-lab > /dev/null 2>&1; then
+  # install jupyterlab
+  # check if pipx is installed
+  if ! command -v pipx > /dev/null 2>&1; then
+    echo "pipx is not installed"
+    echo "Please install pipx in your Dockerfile/VM image before running this script"
+    exit 1
+  fi
+  # install jupyterlab
+  pipx install -q jupyterlab
+  printf "%s\n\n" "🥳 jupyterlab has been installed"
+else
+  printf "%s\n\n" "🥳 jupyterlab is already installed"
+fi
+
+printf "👷 Starting jupyterlab in background..."
+printf "check logs at ${LOG_PATH}"
+$HOME/.local/bin/jupyter-lab --no-browser \
+  "$BASE_URL_FLAG" \
+  --ServerApp.ip='*' \
+  --ServerApp.port="${PORT}" \
+  --ServerApp.token='' \
+  --ServerApp.password='' \
+  > "${LOG_PATH}" 2>&1 &


### PR DESCRIPTION
# Feature
You can customize the module.
# How to use it?
- jupyterlab
```
module "jupyterlab" {
  count    = data.coder_workspace.me.start_count
  source   = "git::https://github.com/LLM-K8s/coder-modules.git//jupyterlab"
  agent_id = coder_agent.main.id
  port = 8888
  subdomain = false
}
```
- filebrowser
```
module "filebrowser" {
  count      = data.coder_workspace.me.start_count
  source     = "git::https://github.com/LLM-K8s/coder-modules.git//filebrowser"
  agent_id   = coder_agent.main.id
  agent_name = "main"
  subdomain  = false
}
```